### PR TITLE
Remove dependency on #valid_exposures

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -25,6 +25,8 @@ it { is_expected.to_not represent(:super_dooper_secret).as(:top_secret).when( :a
 
 it { is_expected.to represent(:dog).using(PetEntity) }
 it { is_expected.to represent(:cat).as(:kitty).using(PetEntity) }
+
+it { is_expected.to represent(:name).with_documentation(type: String) }
 ```
 
 ## Support for Rspec 2.0.0

--- a/grape-entity-matchers.gemspec
+++ b/grape-entity-matchers.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
 
   s.rubyforge_project = "grape-entity-matchers"
 
-  s.add_runtime_dependency 'grape-entity', '~> 0.4.0'
+  s.add_runtime_dependency 'grape-entity', '~> 0.4.6'
   s.add_runtime_dependency 'rspec', '>= 3.2.0'
 
 

--- a/spec/grape_entity_matchers/represent_matcher_spec.rb
+++ b/spec/grape_entity_matchers/represent_matcher_spec.rb
@@ -29,6 +29,9 @@ describe GrapeEntityMatchers do
       expose :name, as: :title
       expose :sub_items, as: :children, using: ItemEntity
     end
+    class Customer < Grape::Entity
+      expose :name, documentation: { type: String, required: true, desc: 'Customer Name' }
+    end
     nil
   end
 
@@ -72,5 +75,17 @@ describe GrapeEntityMatchers do
     subject(:entity) { ItemEntity }
     it { is_expected.to represent(:name).as(:title) }
     it { is_expected.to represent(:sub_items).as(:children).using(ItemEntity) }
+  end
+
+  context 'matchers with documentation' do
+    subject(:entity) { Customer }
+
+    context "allow documentation to be ignored" do
+      it { is_expected.to represent(:name) }
+    end
+
+    context "allow documentationto be matched" do
+      it { is_expected.to represent(:name).with_documentation(type: String, required: true, desc: 'Customer Name') }
+    end
   end
 end


### PR DESCRIPTION
This change makes the matcher compatible with `grape-entity` `~> 0.4.6`. 
There's still more work to do to add compatibility with `0.5.0+`. 

I've also included a change to ignore `:documentation` by default, ensuring back-compatibility.

There is a new `with_documentation` on the `RepresentMatcher` that can optionally be used to check the documentation.