### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/grape-entity-matchers.gemspec
+++ b/grape-entity-matchers.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.description = %q{Shoulda-like matchers for Grape Entity.}
   s.license     = "MIT"
 
-  s.rubyforge_project = "grape-entity-matchers"
-
   s.add_runtime_dependency 'grape-entity', '>= 0.5.0'
   s.add_runtime_dependency 'rspec', '>= 3.2.0'
 


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.